### PR TITLE
Add rich `laufband` CLI

### DIFF
--- a/laufband/cli.py
+++ b/laufband/cli.py
@@ -1,0 +1,284 @@
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+from rich.console import Console
+from rich.layout import Layout
+from rich.live import Live
+from rich.panel import Panel
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
+from rich.table import Table
+from rich.text import Text
+
+from laufband.db import LaufbandDB, T_STATE
+
+
+class LaufbandStatusDisplay:
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self.console = Console()
+        self.db = None
+        
+    def _ensure_db_connection(self):
+        """Ensure database connection exists, create if needed"""
+        if self.db is None and self.db_path.exists():
+            self.db = LaufbandDB(self.db_path, worker="cli_viewer")
+    
+    def get_job_stats(self) -> Dict[str, int] | None:
+        """Get counts of jobs in each state"""
+        self._ensure_db_connection()
+        if self.db is None:
+            return None
+            
+        try:
+            return self.db.get_job_stats()
+        except Exception:
+            # Database was removed or corrupted, reset connection
+            self.db = None
+            return None
+    
+    def get_worker_info(self) -> List[Dict] | None:
+        """Get information about all workers"""
+        self._ensure_db_connection()
+        if self.db is None:
+            return None
+            
+        try:
+            return self.db.get_worker_info()
+        except Exception:
+            # Database was removed or corrupted, reset connection
+            self.db = None
+            return None
+    
+    def create_progress_bar(self, stats: Dict[str, int]) -> Panel:
+        """Create overall progress bar"""
+        total = sum(stats.values())
+        completed = stats['completed']
+        failed = stats['failed']
+        
+        progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            TimeRemainingColumn(),
+        )
+        
+        progress.add_task(
+            f"Overall Progress ({completed + failed}/{total} complete)",
+            total=total,
+            completed=completed + failed
+        )
+        
+        return Panel(progress, title="Overall Progress")
+    
+    def create_stats_table(self, stats: Dict[str, int]) -> Table:
+        """Create job statistics table"""
+        table = Table(title="Job Statistics")
+        table.add_column("State", style="cyan")
+        table.add_column("Count", justify="right", style="magenta")
+        table.add_column("Percentage", justify="right", style="green")
+        
+        total = sum(stats.values())
+        
+        for state, count in stats.items():
+            percentage = f"{(count/total)*100:.1f}%" if total > 0 else "0.0%"
+            
+            # Color code by state
+            state_color = {
+                'completed': 'green',
+                'running': 'yellow',
+                'pending': 'blue',
+                'failed': 'red',
+                'died': 'red bold'
+            }.get(state, 'white')
+            
+            table.add_row(
+                Text(state.title(), style=state_color),
+                str(count),
+                percentage
+            )
+        
+        return table
+    
+    def create_workers_table(self, workers: List[Dict]) -> Table:
+        """Create workers information table"""
+        table = Table(title="Workers")
+        table.add_column("Worker ID", style="cyan")
+        table.add_column("Last Seen", style="yellow")
+        table.add_column("Active Jobs", justify="right", style="magenta")
+        table.add_column("Processed", justify="right", style="green")
+        table.add_column("Max Retries", justify="right", style="blue")
+        table.add_column("Status", style="green")
+        
+        for worker in workers:
+            # Determine if worker is active (seen in last 5 minutes)
+            import datetime
+            try:
+                # SQLite CURRENT_TIMESTAMP format: '2024-01-01 12:00:00'
+                last_seen_str = worker['last_seen']
+                if last_seen_str:
+                    # Parse SQLite timestamp format
+                    last_seen = datetime.datetime.strptime(
+                        last_seen_str, '%Y-%m-%d %H:%M:%S'
+                    )
+                    # Assume UTC since SQLite CURRENT_TIMESTAMP is UTC
+                    last_seen = last_seen.replace(tzinfo=datetime.timezone.utc)
+                    now = datetime.datetime.now(datetime.timezone.utc)
+                    time_diff = (now - last_seen).total_seconds()
+                    status = "Active" if time_diff < 300 else "Inactive"
+                    status_color = "green" if status == "Active" else "red"
+                else:
+                    status = "Unknown"
+                    status_color = "yellow"
+            except Exception:
+                status = "Unknown"
+                status_color = "yellow"
+            
+            table.add_row(
+                worker['worker'],
+                worker['last_seen'],
+                str(worker['active_jobs']),
+                str(worker['processed_jobs']),
+                str(worker['max_retries']),
+                Text(status, style=status_color)
+            )
+        
+        return table
+    
+    def create_waiting_panel(self) -> Panel:
+        """Create panel for when database doesn't exist"""
+        return Panel(
+            f"[yellow]Waiting for database file '{self.db_path}' "
+            + "to be created...[/yellow]\n"
+            + "[dim]Start a laufband process to create the database.[/dim]",
+            title="Waiting for Database"
+        )
+    
+    def display_status(self):
+        """Display the current status"""
+        stats = self.get_job_stats()
+        workers = self.get_worker_info()
+        
+        if stats is None or workers is None:
+            # Database doesn't exist yet
+            self.console.print(self.create_waiting_panel())
+            return
+        
+        # Create layout
+        layout = Layout()
+        layout.split_column(
+            Layout(name="progress", size=5),
+            Layout(name="tables")
+        )
+        
+        layout["tables"].split_row(
+            Layout(name="stats"),
+            Layout(name="workers")
+        )
+        
+        # Add content
+        layout["progress"].update(self.create_progress_bar(stats))
+        layout["stats"].update(Panel(self.create_stats_table(stats)))
+        layout["workers"].update(Panel(self.create_workers_table(workers)))
+        
+        self.console.print(layout)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Laufband CLI Tool")
+    parser.add_argument('--version', action='version', version='Laufband CLI 1.0')
+    parser.add_argument(
+        '--db', 
+        type=str, 
+        default='laufband.sqlite',
+        help='Path to the laufband database file (default: laufband.sqlite)'
+    )
+    
+    subparsers = parser.add_subparsers(dest='command', help='Available commands')
+    
+    # Status command
+    status_parser = subparsers.add_parser('status', help='Show current laufband status')
+    status_parser.add_argument(
+        '--db',
+        type=str,
+        help='Path to the laufband database file'
+    )
+    
+    # Watch command
+    watch_parser = subparsers.add_parser(
+        'watch', help='Watch laufband status in real-time'
+    )
+    watch_parser.add_argument(
+        '--db',
+        type=str,
+        help='Path to the laufband database file'
+    )
+    watch_parser.add_argument(
+        '--interval',
+        type=float,
+        default=2.0,
+        help='Update interval in seconds (default: 2.0)'
+    )
+    
+    args = parser.parse_args()
+    
+    # Default to status if no command given
+    if args.command is None:
+        args.command = 'status'
+    
+    # Determine database path
+    db_path = getattr(args, 'db', None) or 'laufband.sqlite'
+    
+    display = LaufbandStatusDisplay(db_path)
+    
+    if args.command == 'status':
+        display.display_status()
+    elif args.command == 'watch':
+        import time
+        
+        console = Console()
+        try:
+            with Live(console=console, refresh_per_second=1/args.interval) as live:
+                while True:
+                    stats = display.get_job_stats()
+                    workers = display.get_worker_info()
+                    
+                    if stats is None or workers is None:
+                        # Database doesn't exist yet
+                        live.update(display.create_waiting_panel())
+                    else:
+                        # Create layout
+                        layout = Layout()
+                        layout.split_column(
+                            Layout(name="progress", size=5),
+                            Layout(name="tables")
+                        )
+                        
+                        layout["tables"].split_row(
+                            Layout(name="stats"),
+                            Layout(name="workers")
+                        )
+                        
+                        # Add content
+                        layout["progress"].update(display.create_progress_bar(stats))
+                        layout["stats"].update(Panel(display.create_stats_table(stats)))
+                        layout["workers"].update(Panel(display.create_workers_table(workers)))
+                        
+                        live.update(layout)
+                    
+                    time.sleep(args.interval)
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Stopped watching.[/yellow]")
+
+
+if __name__ == "__main__":
+    main()

--- a/laufband/db.py
+++ b/laufband/db.py
@@ -218,3 +218,52 @@ class LaufbandDB:
             )
             row = cursor.fetchone()
         return row[0] if row else None
+
+    def get_job_stats(self) -> dict[str, int]:
+        """Get counts of jobs in each state"""
+        stats = {}
+        states: list[T_STATE] = ["running", "pending", "failed", "completed", "died"]
+        
+        with self.connect() as conn:
+            cursor = conn.cursor()
+            for state in states:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM progress_table WHERE state = ?", (state,)
+                )
+                stats[state] = cursor.fetchone()[0]
+        
+        return stats
+
+    def get_worker_info(self) -> list[dict]:
+        """Get information about all workers with their job statistics"""
+        with self.connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT 
+                    w.worker,
+                    w.last_seen,
+                    COUNT(CASE WHEN p.state = 'running' THEN 1 END) as active_jobs,
+                    COUNT(CASE WHEN p.state = 'completed' THEN 1 END) as completed_jobs,
+                    COUNT(CASE WHEN p.state = 'failed' THEN 1 END) as failed_jobs,
+                    MAX(p.count) as max_retries
+                FROM worker_table w
+                LEFT JOIN progress_table p ON w.worker = p.worker
+                GROUP BY w.worker, w.last_seen
+                ORDER BY w.last_seen DESC
+            """)
+            
+            workers = []
+            for row in cursor.fetchall():
+                (worker, last_seen, active_jobs, completed_jobs, 
+                 failed_jobs, max_retries) = row
+                workers.append({
+                    'worker': worker,
+                    'last_seen': last_seen,
+                    'active_jobs': active_jobs or 0,
+                    'completed_jobs': completed_jobs or 0,
+                    'failed_jobs': failed_jobs or 0,
+                    'processed_jobs': (completed_jobs or 0) + (failed_jobs or 0),
+                    'max_retries': max_retries or 0
+                })
+        
+        return workers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "tqdm>=4.67.1",
     "flufl-lock>=8.1.0",
+    "rich>=14.0.0",
 ]
 
 [dependency-groups]
@@ -54,3 +55,7 @@ exclude = [
     "tests",
     "docs",
 ]
+
+[project.scripts]
+laufband = 'laufband.cli:main'
+

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -134,3 +134,144 @@ def test_heartbeat_timeout(tmp_path: Path):
 def test_db_identifier_none(tmp_path: Path):
     with pytest.raises(ValueError):
         LaufbandDB(tmp_path / "test.db", worker=None)
+
+
+def test_get_job_stats(tracker: LaufbandDB):
+    """Test get_job_stats returns correct counts for each state."""
+    tracker.create(10)
+    
+    # Initially all jobs should be pending
+    stats = tracker.get_job_stats()
+    assert stats["pending"] == 10
+    assert stats["running"] == 0
+    assert stats["completed"] == 0
+    assert stats["failed"] == 0
+    assert stats["died"] == 0
+    
+    # Process some jobs
+    jobs = list(tracker)  # This marks all as running
+    assert len(jobs) == 10
+    
+    # Complete some jobs
+    tracker.finalize(0, "completed")
+    tracker.finalize(1, "completed")
+    tracker.finalize(2, "failed")
+    
+    stats = tracker.get_job_stats()
+    assert stats["pending"] == 0
+    assert stats["running"] == 7  # 10 - 3 processed
+    assert stats["completed"] == 2
+    assert stats["failed"] == 1
+    assert stats["died"] == 0
+
+
+def test_get_worker_info_single_worker(tracker: LaufbandDB):
+    """Test get_worker_info with a single worker."""
+    tracker.create(5)
+    tracker.worker = "test_worker"
+    
+    # Initially no workers should be in the table
+    worker_info = tracker.get_worker_info()
+    assert len(worker_info) == 0
+    
+    # Process some jobs (this creates worker entry)
+    jobs = list(tracker)
+    assert len(jobs) == 5
+    
+    worker_info = tracker.get_worker_info()
+    assert len(worker_info) == 1
+    
+    worker = worker_info[0]
+    assert worker["worker"] == "test_worker"
+    assert worker["active_jobs"] == 5
+    assert worker["completed_jobs"] == 0
+    assert worker["failed_jobs"] == 0
+    assert worker["processed_jobs"] == 0
+    assert worker["max_retries"] == 1  # count starts at 0, incremented to 1 when running
+    assert worker["last_seen"] is not None
+    
+    # Complete some jobs
+    tracker.finalize(0, "completed")
+    tracker.finalize(1, "completed")
+    tracker.finalize(2, "failed")
+    
+    worker_info = tracker.get_worker_info()
+    worker = worker_info[0]
+    assert worker["active_jobs"] == 2  # 5 - 3 processed
+    assert worker["completed_jobs"] == 2
+    assert worker["failed_jobs"] == 1
+    assert worker["processed_jobs"] == 3  # completed + failed
+
+
+def test_get_worker_info_multiple_workers(tmp_path: Path):
+    """Test get_worker_info with multiple workers."""
+    db_path = tmp_path / "test_multi_worker.db"
+    
+    # Worker 1 processes first batch
+    worker1 = LaufbandDB(db_path, worker="worker_1")
+    worker1.create(10)
+    
+    # Process only 3 jobs with worker1
+    jobs1 = []
+    worker1_iter = iter(worker1)
+    for _ in range(3):
+        job = next(worker1_iter)
+        jobs1.append(job)
+        worker1.finalize(job, "completed")
+    
+    # Worker 2 processes next batch
+    worker2 = LaufbandDB(db_path, worker="worker_2")
+    
+    # Process 2 jobs with worker2
+    jobs2 = []
+    worker2_iter = iter(worker2)
+    for _ in range(2):
+        job = next(worker2_iter)
+        jobs2.append(job)
+    
+    worker2.finalize(jobs2[0], "completed")
+    worker2.finalize(jobs2[1], "failed")
+    
+    # Check worker info
+    worker_info = worker1.get_worker_info()
+    assert len(worker_info) == 2
+    
+    # Workers should be ordered by last_seen DESC
+    workers_by_name = {w["worker"]: w for w in worker_info}
+    
+    assert "worker_1" in workers_by_name
+    assert "worker_2" in workers_by_name
+    
+    w1 = workers_by_name["worker_1"]
+    assert w1["completed_jobs"] == 3
+    assert w1["failed_jobs"] == 0
+    assert w1["processed_jobs"] == 3
+    assert w1["active_jobs"] == 0
+    
+    w2 = workers_by_name["worker_2"]
+    assert w2["completed_jobs"] == 1
+    assert w2["failed_jobs"] == 1
+    assert w2["processed_jobs"] == 2
+    assert w2["active_jobs"] == 0
+
+
+def test_get_worker_info_with_retries(tmp_path: Path):
+    """Test get_worker_info tracks max retries correctly."""
+    db_path = tmp_path / "test_retries.db"
+    worker = LaufbandDB(db_path, worker="retry_worker", max_died_retries=2)
+    worker.create(3)
+    
+    jobs = list(worker)
+    
+    # Simulate some retries by marking jobs as died and reprocessing
+    worker.finalize(0, "died")
+    worker.finalize(1, "died")
+    
+    # Process died jobs again (this increments count)
+    jobs_retry = list(worker)  # Should get the died jobs back
+    
+    worker_info = worker.get_worker_info()
+    worker_data = worker_info[0]
+    
+    # max_retries should reflect the highest count value
+    assert worker_data["max_retries"] >= 1  # Jobs have been retried at least once

--- a/uv.lock
+++ b/uv.lock
@@ -475,6 +475,7 @@ version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "flufl-lock" },
+    { name = "rich" },
     { name = "tqdm" },
 ]
 
@@ -495,6 +496,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flufl-lock", specifier = ">=8.1.0" },
+    { name = "rich", specifier = ">=14.0.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
 


### PR DESCRIPTION
- Add test_get_job_stats() for job state counting functionality
- Add test_get_worker_info_single_worker() for single worker statistics
- Add test_get_worker_info_multiple_workers() for multi-worker scenarios
- Add test_get_worker_info_with_retries() for retry counting validation
- Tests cover all job states (pending, running, completed, failed, died)
- Verify processed job counts, active job tracking, and max retry statistics
- Follow existing test patterns using fixtures and tmp_path

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>