### PR TITLE
add `Graphband.has_more_jobs`

### DIFF
--- a/laufband/graphband.py
+++ b/laufband/graphband.py
@@ -161,6 +161,7 @@ class Graphband(t.Generic[TaskTypeVar]):
         # here we keep track of failed job data to be retried later
         self._failed_job_cache = {}
         self._iterator = None
+        self._iterator_completed = False
         self._heartbeat_timeout = heartbeat_timeout
         self._heartbeat_interval = heartbeat_interval
         self._labels = frozenset(labels or [])
@@ -257,6 +258,101 @@ class Graphband(t.Generic[TaskTypeVar]):
         """Return the database URL."""
         return self._db
 
+    @property
+    def has_more_jobs(self) -> bool:
+        """Check if there are any more jobs that this worker could process.
+        
+        Returns
+        -------
+        bool
+            True if there are jobs that this worker could potentially process,
+            False if all jobs are either completed or permanently failed/killed.
+            
+        Notes
+        -----
+        Simple logic: Check if there are processable jobs in the failed cache
+        or incomplete tasks in the database that match our labels and haven't 
+        exceeded retry limits.
+        
+        Jobs with label mismatches are ignored since this worker would never
+        pick them up.
+        
+        Examples
+        --------
+        >>> pbar = Graphband(tasks, labels={'worker-a'})
+        >>> list(pbar)  # Process all available jobs  
+        >>> pbar.has_more_jobs  # Should be False if no more jobs for this worker
+        False
+        """
+        if self.disabled:
+            return False
+        
+        # Simple logic - check failed cache and database
+        retryable_failed_jobs = 0
+        incomplete_jobs = 0
+        
+        with self.lock:
+            with Session(self._engine) as session:
+                # Check failed job cache
+                for task in self._failed_job_cache.values():
+                    if not task.requirements.issubset(self.labels):
+                        continue
+                    
+                    task_entry = session.get(TaskEntry, task.id)
+                    if task_entry is None:
+                        retryable_failed_jobs += 1  # New task, can be processed
+                    elif (task_entry.failed_retries < self._max_failed_retries and
+                          task_entry.killed_retries < self._max_killed_retries):
+                        retryable_failed_jobs += 1
+                
+                # Check database for incomplete tasks
+                workflow = (
+                    session.query(WorkflowEntry)
+                    .filter(WorkflowEntry.id == "main")
+                    .first()
+                )
+                if workflow is not None:
+                    for task_entry in workflow.tasks:
+                        # Skip if labels don't match
+                        if not set(task_entry.requirements).issubset(self.labels):
+                            continue
+                        
+                        # Count incomplete tasks that can be retried
+                        if (not task_entry.completed and 
+                            task_entry.failed_retries < self._max_failed_retries and
+                            task_entry.killed_retries < self._max_killed_retries):
+                            incomplete_jobs += 1
+                    
+                    # If no incomplete jobs found but iterator hasn't completed,
+                    # check if we have any tasks matching our labels
+                    if incomplete_jobs == 0 and not self._iterator_completed:
+                        # Check if all tasks matching our labels are complete
+                        total_matching_tasks = len([
+                            t for t in workflow.tasks 
+                            if set(t.requirements).issubset(self.labels)
+                        ])
+                        completed_matching_tasks = len([
+                            t for t in workflow.tasks 
+                            if set(t.requirements).issubset(self.labels) and t.completed
+                        ])
+                        
+                        # If we have tasks in DB and all matching ones are complete, 
+                        # and no retryable failed jobs, then no more jobs
+                        if (total_matching_tasks > 0 and 
+                            completed_matching_tasks == total_matching_tasks and 
+                            retryable_failed_jobs == 0):
+                            return False
+                        
+                        # Otherwise, there might be more tasks to process
+                        return True
+                else:
+                    # No workflow exists yet - if we haven't completed iteration, 
+                    # assume there are jobs from the original graph
+                    if not self._iterator_completed:
+                        return True
+        
+        return (retryable_failed_jobs + incomplete_jobs) > 0
+
     def __iter__(self) -> Iterator[Task[TaskTypeVar]]:
         """The generator that handles the iteration logic."""
 
@@ -278,6 +374,7 @@ class Graphband(t.Generic[TaskTypeVar]):
             yield from self._iterator
             return
 
+        completed_naturally = True
         for task in self._iterator:
             if not task.requirements.issubset(self.labels):
                 log.debug(
@@ -389,6 +486,7 @@ class Graphband(t.Generic[TaskTypeVar]):
 
                         worker.status = WorkerStatus.IDLE
                         session.commit()
+                    completed_naturally = False
                     break
             with self.lock:
                 with Session(self._engine) as session:
@@ -421,6 +519,9 @@ class Graphband(t.Generic[TaskTypeVar]):
                     worker.status = WorkerStatus.IDLE
                     session.commit()
             if self._close_trigger:
+                completed_naturally = False
                 break
+        if completed_naturally:
+            self._iterator_completed = True
         self._thread_event.set()
         self._heartbeat_thread.join()

--- a/tests/test_graphband.py
+++ b/tests/test_graphband.py
@@ -592,7 +592,7 @@ def blocked_dependency_graph_task():
 def test_has_more_jobs_with_blocked_dependencies(tmp_path):
     """Test has_more_jobs when dependencies are blocked by label mismatches.
 
-    This test verifies the TODO scenario where:
+    This test verifies the scenario where:
     - a --> b --> c dependency chain
     - b needs a different label than a, c
     - has_more_jobs for the a/c worker should be true until c is completed
@@ -659,7 +659,6 @@ def test_has_more_jobs_with_blocked_dependencies(tmp_path):
     assert special_worker.has_more_jobs is False
 
 
-# TODO: need to check that this LLM Agent generated test makes sense!
 def test_has_more_jobs_with_killed_workers(tmp_path):
     """Test has_more_jobs behavior when workers are killed
     and tasks exceed retry limits."""
@@ -673,101 +672,64 @@ def test_has_more_jobs_with_killed_workers(tmp_path):
         target=task_worker,
         args=(sequential_task, lock_path, db, file, 3),
         kwargs={
-            "heartbeat_timeout": 2,
-            "heartbeat_interval": 1,
+            "heartbeat_timeout": 1,
+            "heartbeat_interval": 0.5,
             "max_killed_retries": 0,  # No retries allowed for killed tasks
             "identifier": "killed-worker",
         },
     )
     proc.start()
-    time.sleep(0.5)  # Let the worker start one task
+    time.sleep(2)  # Let the worker start one task
     proc.kill()
     proc.join()
 
-    # Wait for heartbeat to expire and task to be marked as killed
-    time.sleep(3)
-
-    # Create a new worker to verify has_more_jobs behavior
-    check_worker = Graphband(
+    time.sleep(2)
+    # need to start another worker to mark the job as killed in the db
+    _ = Graphband(
         sequential_task(),
         db=db,
         lock=Lock(lock_path),
         heartbeat_timeout=2,
         heartbeat_interval=1,
-        max_killed_retries=0,  # Same retry limit
-        identifier="check-worker",
+        identifier="update-worker",
     )
+    time.sleep(2)
 
-    # Should have more jobs initially (remaining tasks that weren't killed)
-    assert check_worker.has_more_jobs is True
-
-    # Process remaining tasks (killed task should not be retried)
-    items = list(check_worker)
-    assert len(items) == 9  # Should process 9 tasks (excluding the killed one)
-
-    # Should have no more jobs after processing all retryable tasks
-    assert check_worker.has_more_jobs is False
 
     # Verify the killed task is permanently blocked
     engine = create_engine(db)
     with Session(engine) as session:
         tasks = session.query(TaskEntry).all()
-        killed_task = next(
-            (t for t in tasks if t.current_status.status == TaskStatusEnum.KILLED), None
-        )
-        assert killed_task is not None
-        assert killed_task.killed_retries > 0
-
         # Verify we have exactly one killed task and 9 completed tasks
         killed_tasks = [
             t for t in tasks if t.current_status.status == TaskStatusEnum.KILLED
         ]
-        completed_tasks = [
-            t for t in tasks if t.current_status.status == TaskStatusEnum.COMPLETED
-        ]
         assert len(killed_tasks) == 1
-        assert len(completed_tasks) == 9
 
-    # Test case where killed tasks CAN be retried (max_killed_retries=2)
-    lock_path2 = f"{tmp_path}/graphband2.lock"
-    db2 = f"sqlite:///{tmp_path}/graphband2.sqlite"
-    file2 = f"{tmp_path}/output2.txt"
-
-    proc2 = multiprocessing.Process(
-        target=task_worker,
-        args=(sequential_task, lock_path2, db2, file2, 3),
-        kwargs={
-            "heartbeat_timeout": 2,
-            "heartbeat_interval": 1,
-            "max_killed_retries": 2,  # Allow retries for killed tasks
-            "identifier": "killed-worker-2",
-        },
-    )
-    proc2.start()
-    time.sleep(0.5)  # Let it start one task
-    proc2.kill()
-    proc2.join()
-
-    # Wait for heartbeat to expire
-    time.sleep(3)
-
-    # Create worker that can retry killed tasks
-    retry_worker = Graphband(
+    no_retries_worker = Graphband(
         sequential_task(),
-        db=db2,
-        lock=Lock(lock_path2),
+        db=db,
+        lock=Lock(lock_path),
+        heartbeat_timeout=2,
+        heartbeat_interval=1,
+        max_killed_retries=0,  # No retries allowed
+        identifier="no-retries-worker",
+    )
+
+    retries_worker = Graphband(
+        sequential_task(),
+        db=db,
+        lock=Lock(lock_path),
         heartbeat_timeout=2,
         heartbeat_interval=1,
         max_killed_retries=2,  # Allow retries
-        identifier="retry-worker",
+        identifier="retries-worker",
     )
 
-    # Should have more jobs (including retryable killed task)
-    assert retry_worker.has_more_jobs is True
-
-    # Process all tasks including retry of killed task
-    retry_items = list(retry_worker)
-    assert len(retry_items) == 10  # Should process all 10 tasks
-
-    # Should have no more jobs after completion
-    assert retry_worker.has_more_jobs is False
+    assert no_retries_worker.has_more_jobs is True
+    assert retries_worker.has_more_jobs is True
+    assert len(list(no_retries_worker)) == 9
+    assert no_retries_worker.has_more_jobs is False
+    assert retries_worker.has_more_jobs is True
+    assert len(list(retries_worker)) == 1
+    assert retries_worker.has_more_jobs is False

--- a/tests/test_graphband.py
+++ b/tests/test_graphband.py
@@ -563,7 +563,7 @@ def test_has_more_jobs(tmp_path):
         max_failed_retries=2,
         identifier="retry-worker-2",
     )
-    assert w3.has_more_jobs is False  # all jobs are no completed succesfully
+    assert w3.has_more_jobs is False  # all jobs are no completed successfully
 
 
 def blocked_dependency_graph_task():
@@ -661,7 +661,8 @@ def test_has_more_jobs_with_blocked_dependencies(tmp_path):
 
 # TODO: need to check that this LLM Agent generated test makes sense!
 def test_has_more_jobs_with_killed_workers(tmp_path):
-    """Test has_more_jobs behavior when workers are killed and tasks exceed retry limits."""
+    """Test has_more_jobs behavior when workers are killed
+    and tasks exceed retry limits."""
     # Test case where killed tasks cannot be retried (max_killed_retries=0)
     lock_path = f"{tmp_path}/graphband.lock"
     db = f"sqlite:///{tmp_path}/graphband.sqlite"

--- a/tests/test_graphband.py
+++ b/tests/test_graphband.py
@@ -695,7 +695,6 @@ def test_has_more_jobs_with_killed_workers(tmp_path):
     )
     time.sleep(2)
 
-
     # Verify the killed task is permanently blocked
     engine = create_engine(db)
     with Session(engine) as session:


### PR DESCRIPTION
- [ ] update docs on how to use this to process until all jobs are done. Include timeout / how often to iterate. Include updating the generator as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a has_more_jobs property so workers can detect available work (considers labels, dependencies, retryable failures, and iterator state) and iterator-completion tracking so availability can be queried without waiting for iterable exhaustion.

- Tests
  - Added end-to-end tests covering task progression, label-blocked dependencies, killed-worker retry policies, and DB assertions to validate job-availability reporting and worker coordination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->