### PR TITLE
Update identifier to use environment variable fallback

### DIFF
--- a/laufband/graphband.py
+++ b/laufband/graphband.py
@@ -99,7 +99,7 @@ class Graphband(t.Generic[TaskTypeVar]):
         *,
         lock: Lock = Lock("graphband.lock"),
         db: str = "sqlite:///graphband.sqlite",
-        identifier: str | t.Callable = os.getenv("LAUFBAND_IDENTIFIER") or (lambda: f"{socket.gethostname()}:{os.getpid()}")
+        identifier: str | t.Callable = os.getenv("LAUFBAND_IDENTIFIER") or (lambda: f"{socket.gethostname()}:{os.getpid()}"),
         failure_policy: t.Literal["continue", "stop"] = os.getenv(
             "LAUFBAND_FAILURE_POLICY", "continue"
         ),

--- a/laufband/graphband.py
+++ b/laufband/graphband.py
@@ -99,7 +99,7 @@ class Graphband(t.Generic[TaskTypeVar]):
         *,
         lock: Lock = Lock("graphband.lock"),
         db: str = "sqlite:///graphband.sqlite",
-        identifier: str | t.Callable = os.getpid,
+        identifier: str | t.Callable = os.getenv("LAUFBAND_IDENTIFIER", os.getpid),
         failure_policy: t.Literal["continue", "stop"] = os.getenv(
             "LAUFBAND_FAILURE_POLICY", "continue"
         ),

--- a/laufband/graphband.py
+++ b/laufband/graphband.py
@@ -99,7 +99,8 @@ class Graphband(t.Generic[TaskTypeVar]):
         *,
         lock: Lock = Lock("graphband.lock"),
         db: str = "sqlite:///graphband.sqlite",
-        identifier: str | t.Callable = os.getenv("LAUFBAND_IDENTIFIER") or (lambda: f"{socket.gethostname()}:{os.getpid()}"),
+        identifier: str | t.Callable = os.getenv("LAUFBAND_IDENTIFIER")
+        or (lambda: f"{socket.gethostname()}:{os.getpid()}"),
         failure_policy: t.Literal["continue", "stop"] = os.getenv(
             "LAUFBAND_FAILURE_POLICY", "continue"
         ),

--- a/laufband/graphband.py
+++ b/laufband/graphband.py
@@ -92,8 +92,8 @@ class SizedGraphTraversalProtocol(GraphTraversalProtocol[TaskTypeVar]):
 
 
 def _identifier_default_fn() -> str:
-    if os.getenv("LAUFBAND_IDENTIFIER"):
-        return str(os.getenv("LAUFBAND_IDENTIFIER"))
+    if ident := os.getenv("LAUFBAND_IDENTIFIER"):
+        return str(ident)
     return f"{socket.gethostname()}:{os.getpid()}"
 
 

--- a/laufband/graphband.py
+++ b/laufband/graphband.py
@@ -99,7 +99,7 @@ class Graphband(t.Generic[TaskTypeVar]):
         *,
         lock: Lock = Lock("graphband.lock"),
         db: str = "sqlite:///graphband.sqlite",
-        identifier: str | t.Callable = os.getenv("LAUFBAND_IDENTIFIER", os.getpid),
+        identifier: str | t.Callable = os.getenv("LAUFBAND_IDENTIFIER") or (lambda: f"{socket.gethostname()}:{os.getpid()}")
         failure_policy: t.Literal["continue", "stop"] = os.getenv(
             "LAUFBAND_FAILURE_POLICY", "continue"
         ),
@@ -134,17 +134,17 @@ class Graphband(t.Generic[TaskTypeVar]):
             The timeout in seconds to consider a worker as dead if it has not been seen
             in the last `heartbeat_timeout` seconds. This is used to mark jobs
             as "died" if the worker process is killed unexpectedly.
-            Defaults to 1 hour or the value of the environment variable
+            Defaults to 60 seconds or the value of the environment variable
             ``LAUFBAND_HEARTBEAT_TIMEOUT`` if set.
-        max_died_retries : int
-            The number of times to retry processing items that have been marked as died.
+        max_killed_retries : int
+            The number of times to retry processing items that have been marked as killed.
             If set to 0, no retries will be attempted.
             Defaults to 0 or the value of the environment variable
-            ``LAUFBAND_MAX_DIED_RETRIES`` if set.
+            ``LAUFBAND_MAX_KILLED_RETRIES`` if set.
         disabled : bool
             If True, disable Graphband features and return a simple iterator.
             Can also be set via the environment variable
-            ``LAUFBAND_DISABLE``.
+            ``LAUFBAND_DISABLED``.
         tqdm_kwargs : dict
             Additional arguments to pass to tqdm.
         """
@@ -154,7 +154,7 @@ class Graphband(t.Generic[TaskTypeVar]):
         self._close_trigger = False
         self.failure_policy = failure_policy
         self.tqdm_kwargs = tqdm_kwargs or {}
-        self._identifier = identifier() if callable(identifier) else identifier
+        self._identifier = str(identifier()) if callable(identifier) else identifier
         self._max_failed_retries = max_failed_retries
         self._max_killed_retries = max_killed_retries
         self._db = db

--- a/laufband/graphband.py
+++ b/laufband/graphband.py
@@ -105,7 +105,7 @@ class Graphband(t.Generic[TaskTypeVar]):
         *,
         lock: Lock = Lock("graphband.lock"),
         db: str = "sqlite:///graphband.sqlite",
-        identifier: str | t.Callable = _identifier_default_fn,
+        identifier: str | t.Callable[[], str] = _identifier_default_fn,
         failure_policy: t.Literal["continue", "stop"] = os.getenv(
             "LAUFBAND_FAILURE_POLICY", "continue"
         ),
@@ -127,10 +127,10 @@ class Graphband(t.Generic[TaskTypeVar]):
         db : str
             The database connection string. Defaults to "sqlite:///graphband.sqlite".
         identifier : str | callable, optional
-            A unique identifier for the worker. If not set, the process ID will be used.
-            If a callable is provided, it will be called to generate the identifier.
-            Must be unique across all workers. Can be set via the environment variable
-            ``LAUFBAND_IDENTIFIER``.
+            A unique identifier for the worker. If not provided or empty/whitespace,
+            it defaults to "{hostname}:{pid}". If a zero-argument callable is provided,
+            it will be called and the result used. Must be unique across all
+            workers. Can be set via the environment variable ``LAUFBAND_IDENTIFIER``.
         failure_policy : str
             If an error occurs, the generator will always yield that error.
             With the "continue" policy, other processes will continue,

--- a/laufband/graphband.py
+++ b/laufband/graphband.py
@@ -91,7 +91,7 @@ class SizedGraphTraversalProtocol(GraphTraversalProtocol[TaskTypeVar]):
     def __len__(self) -> int: ...
 
 
-def _identifier_default() -> str:
+def _identifier_default_fn() -> str:
     if os.getenv("LAUFBAND_IDENTIFIER"):
         return str(os.getenv("LAUFBAND_IDENTIFIER"))
     return f"{socket.gethostname()}:{os.getpid()}"
@@ -105,7 +105,7 @@ class Graphband(t.Generic[TaskTypeVar]):
         *,
         lock: Lock = Lock("graphband.lock"),
         db: str = "sqlite:///graphband.sqlite",
-        identifier: str | t.Callable = _identifier_default(),
+        identifier: str | t.Callable = _identifier_default_fn,
         failure_policy: t.Literal["continue", "stop"] = os.getenv(
             "LAUFBAND_FAILURE_POLICY", "continue"
         ),
@@ -214,7 +214,7 @@ class Graphband(t.Generic[TaskTypeVar]):
                     id=self._identifier,
                     status=WorkerStatus.IDLE,
                     hostname=socket.gethostname(),
-                    pid=f"{socket.gethostname()}:{os.getpid()}",
+                    pid=os.getpid(),
                     heartbeat_interval=self._heartbeat_interval,
                     heartbeat_timeout=self._heartbeat_timeout,
                     labels=list(self.labels),

--- a/laufband/graphband.py
+++ b/laufband/graphband.py
@@ -91,6 +91,12 @@ class SizedGraphTraversalProtocol(GraphTraversalProtocol[TaskTypeVar]):
     def __len__(self) -> int: ...
 
 
+def _identifier_default() -> str:
+    if os.getenv("LAUFBAND_IDENTIFIER"):
+        return str(os.getenv("LAUFBAND_IDENTIFIER"))
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
 class Graphband(t.Generic[TaskTypeVar]):
     def __init__(
         self,
@@ -99,8 +105,7 @@ class Graphband(t.Generic[TaskTypeVar]):
         *,
         lock: Lock = Lock("graphband.lock"),
         db: str = "sqlite:///graphband.sqlite",
-        identifier: str | t.Callable = os.getenv("LAUFBAND_IDENTIFIER")
-        or (lambda: f"{socket.gethostname()}:{os.getpid()}"),
+        identifier: str | t.Callable = _identifier_default(),
         failure_policy: t.Literal["continue", "stop"] = os.getenv(
             "LAUFBAND_FAILURE_POLICY", "continue"
         ),
@@ -138,8 +143,8 @@ class Graphband(t.Generic[TaskTypeVar]):
             Defaults to 60 seconds or the value of the environment variable
             ``LAUFBAND_HEARTBEAT_TIMEOUT`` if set.
         max_killed_retries : int
-            The number of times to retry processing items that have been marked as killed.
-            If set to 0, no retries will be attempted.
+            The number of times to retry processing items that have been
+            marked as killed. If set to 0, no retries will be attempted.
             Defaults to 0 or the value of the environment variable
             ``LAUFBAND_MAX_KILLED_RETRIES`` if set.
         disabled : bool
@@ -155,7 +160,7 @@ class Graphband(t.Generic[TaskTypeVar]):
         self._close_trigger = False
         self.failure_policy = failure_policy
         self.tqdm_kwargs = tqdm_kwargs or {}
-        self._identifier = str(identifier()) if callable(identifier) else identifier
+        self._identifier = identifier() if callable(identifier) else identifier
         self._max_failed_retries = max_failed_retries
         self._max_killed_retries = max_killed_retries
         self._db = db
@@ -209,7 +214,7 @@ class Graphband(t.Generic[TaskTypeVar]):
                     id=self._identifier,
                     status=WorkerStatus.IDLE,
                     hostname=socket.gethostname(),
-                    pid=os.getpid(),
+                    pid=f"{socket.gethostname()}:{os.getpid()}",
                     heartbeat_interval=self._heartbeat_interval,
                     heartbeat_timeout=self._heartbeat_timeout,
                     labels=list(self.labels),

--- a/tests/test_graphband.py
+++ b/tests/test_graphband.py
@@ -273,7 +273,7 @@ def test_multiprocessing_sequential_task(tmp_path, num_processes):
         # increase the timeout for more processes
         pool.starmap(
             task_worker,
-            [(sequential_task, lock_path, db, file, num_processes * 0.2)]
+            [(sequential_task, lock_path, db, file, num_processes * 0.3)]
             * num_processes,
         )
 

--- a/tests/test_graphband.py
+++ b/tests/test_graphband.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import socket
 import time
 import typing as t
 
@@ -355,11 +356,11 @@ def test_kill_sequential_task_worker(tmp_path):
     )
 
     with Session(engine) as session:
-        w1 = session.get(WorkerEntry, proc.pid)
+        w1 = session.get(WorkerEntry, f"{socket.gethostname()}:{proc.pid}")
         assert w1 is not None
         assert w1.status == WorkerStatus.KILLED
         assert len(w1.running_tasks) == 0
-        w2 = session.get(WorkerEntry, os.getpid())
+        w2 = session.get(WorkerEntry, f"{socket.gethostname()}:{os.getpid()}")
         assert w2 is not None
         assert w2.status == WorkerStatus.OFFLINE
         assert len(w2.running_tasks) == 0

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import typing as t
 
 import pytest
@@ -32,11 +33,11 @@ def test_monitor(graphband_state):
     worker = m.get_workers()
     tasks = m.get_tasks()
     assert len(worker) == 1
-    assert worker[0].id == str(os.getpid())
+    assert worker[0].id == f"{socket.gethostname()}:{os.getpid()}"
     assert len(tasks) == 6
     assert tasks[0].id == "task_0"
     assert tasks[0].current_status.status == TaskStatusEnum.COMPLETED
-    assert tasks[0].current_status.worker.id == str(os.getpid())
+    assert tasks[0].current_status.worker.id == worker[0].id
     assert tasks[-1].current_status.status == TaskStatusEnum.FAILED
 
     assert tasks[0].active_workers == 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker identifier can be configured via LAUFBAND_IDENTIFIER; when unset it falls back to a host:pid string and callables are supported as providers.

* **Documentation**
  * Clarified heartbeat timeout default is 60 seconds.
  * Renamed max_died_retries → max_killed_retries and documented LAUFBAND_MAX_KILLED_RETRIES.
  * Renamed LAUFBAND_DISABLE → LAUFBAND_DISABLED.

* **Tests**
  * Updated tests to use host:pid worker IDs for assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->