### PR TITLE
check for killed worker every heartbeat and not just when starting

### DIFF
--- a/laufband/db.py
+++ b/laufband/db.py
@@ -83,6 +83,7 @@ class WorkerEntry(Base):
     # One worker can appear in many TaskStatusEntries
     task_statuses: Mapped[List["TaskStatusEntry"]] = relationship(
         back_populates="worker",
+        order_by=lambda: TaskStatusEntry.timestamp,
     )
 
     @property
@@ -94,15 +95,10 @@ class WorkerEntry(Base):
 
     @property
     def running_tasks(self) -> set["TaskEntry"]:
-        """Get all running tasks for this worker."""
-        running_tasks = set()
-        for status in self.task_statuses:
-            if status.status == TaskStatusEnum.RUNNING:
-                running_tasks.add(status.task)
-            else:
-                # remove if running has been outdated.
-                running_tasks.discard(status.task)
-        return running_tasks
+        latest: dict["TaskEntry", TaskStatusEnum] = {}
+        for s in self.task_statuses:
+            latest[s.task] = s.status
+        return {t for t, st in latest.items() if st == TaskStatusEnum.RUNNING}
 
 
 # --- TaskStatusEntry ---

--- a/laufband/heartbeat.py
+++ b/laufband/heartbeat.py
@@ -37,7 +37,9 @@ def heartbeat(lock: Lock, db: str, identifier: str, stop_event: threading.Event)
                 # check expired heartbeats
                 for worker in (
                     session.query(WorkerEntry)
-                    .filter(WorkerEntry.status.in_([WorkerStatus.BUSY, WorkerStatus.IDLE]))
+                    .filter(
+                        WorkerEntry.status.in_([WorkerStatus.BUSY, WorkerStatus.IDLE])
+                    )
                     .all()
                 ):
                     if worker.heartbeat_expired:

--- a/laufband/heartbeat.py
+++ b/laufband/heartbeat.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from flufl.lock import Lock
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from laufband.db import (
     TaskStatusEntry,
@@ -24,6 +24,7 @@ def heartbeat(lock: Lock, db: str, identifier: str, stop_event: threading.Event)
                 raise ValueError(f"Worker with identifier {identifier} not found.")
             worker.last_heartbeat = datetime.now()
             heartbeat_interval = worker.heartbeat_interval
+            session.add(worker)
             session.commit()
 
     while not stop_event.wait(heartbeat_interval):
@@ -33,23 +34,26 @@ def heartbeat(lock: Lock, db: str, identifier: str, stop_event: threading.Event)
                 if worker is None:
                     raise ValueError(f"Worker with identifier {identifier} not found.")
                 worker.last_heartbeat = datetime.now()
-
+                session.add(worker)
                 # check expired heartbeats
-                for worker in (
+                workflow_id = worker.workflow_id
+                for w in (
                     session.query(WorkerEntry)
+                    .options(selectinload(WorkerEntry.task_statuses))
                     .filter(
-                        WorkerEntry.status.in_([WorkerStatus.BUSY, WorkerStatus.IDLE])
+                        WorkerEntry.workflow_id == workflow_id,
+                        WorkerEntry.status.in_([WorkerStatus.BUSY, WorkerStatus.IDLE]),
                     )
                     .all()
                 ):
-                    if worker.heartbeat_expired:
-                        worker.status = WorkerStatus.KILLED
-                        for task in worker.running_tasks:
+                    if w.heartbeat_expired:
+                        w.status = WorkerStatus.KILLED
+                        for task in w.running_tasks:
                             task_status = TaskStatusEntry(
-                                status=TaskStatusEnum.KILLED, worker=worker, task=task
+                                status=TaskStatusEnum.KILLED, worker=w, task=task
                             )
                             session.add(task_status)
-                        session.add(worker)
+                        session.add(w)
                 session.commit()
 
     with lock:
@@ -57,4 +61,5 @@ def heartbeat(lock: Lock, db: str, identifier: str, stop_event: threading.Event)
             worker = session.get(WorkerEntry, identifier)
             if worker is not None:
                 worker.status = WorkerStatus.OFFLINE
+                session.add(worker)
                 session.commit()

--- a/laufband/heartbeat.py
+++ b/laufband/heartbeat.py
@@ -25,21 +25,6 @@ def heartbeat(lock: Lock, db: str, identifier: str, stop_event: threading.Event)
             worker.last_heartbeat = datetime.now()
             heartbeat_interval = worker.heartbeat_interval
             session.commit()
-            # check expired heartbeats
-            for worker in (
-                session.query(WorkerEntry)
-                .filter(WorkerEntry.status.in_([WorkerStatus.BUSY, WorkerStatus.IDLE]))
-                .all()
-            ):
-                if worker.heartbeat_expired:
-                    worker.status = WorkerStatus.KILLED
-                    for task in worker.running_tasks:
-                        task_status = TaskStatusEntry(
-                            status=TaskStatusEnum.KILLED, worker=worker, task=task
-                        )
-                        session.add(task_status)
-                    session.add(worker)
-            session.commit()
 
     while not stop_event.wait(heartbeat_interval):
         with lock:
@@ -48,7 +33,23 @@ def heartbeat(lock: Lock, db: str, identifier: str, stop_event: threading.Event)
                 if worker is None:
                     raise ValueError(f"Worker with identifier {identifier} not found.")
                 worker.last_heartbeat = datetime.now()
+
+                # check expired heartbeats
+                for worker in (
+                    session.query(WorkerEntry)
+                    .filter(WorkerEntry.status.in_([WorkerStatus.BUSY, WorkerStatus.IDLE]))
+                    .all()
+                ):
+                    if worker.heartbeat_expired:
+                        worker.status = WorkerStatus.KILLED
+                        for task in worker.running_tasks:
+                            task_status = TaskStatusEntry(
+                                status=TaskStatusEnum.KILLED, worker=worker, task=task
+                            )
+                            session.add(task_status)
+                        session.add(worker)
                 session.commit()
+
     with lock:
         with session:
             worker = session.get(WorkerEntry, identifier)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Heartbeat expiration is now processed on every cycle, ensuring unresponsive workers are promptly detected and their running tasks are marked as killed.
  - Prevents tasks from remaining stuck in running or idle states after a worker stops sending heartbeats.
  - Improves accuracy of task status reporting across the UI/API.

- Refactor
  - Streamlined heartbeat handling to perform expiration checks continuously during the periodic loop for more consistent cleanup and recovery from worker failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->